### PR TITLE
SDNQ Atten: rotate hadamard on a contiguous tensor

### DIFF
--- a/src/sdnq/quant_utils.py
+++ b/src/sdnq/quant_utils.py
@@ -201,6 +201,8 @@ def rotate_hadamard(weight: torch.Tensor, group_size: int = 256, hadamard: torch
     if is_conv:
         weight_shape = list(weight.shape)[1:]
         weight = weight.flatten(1,-1)
+    if not weight.is_contiguous(): # a transposed activation view makes the grouped matmul an order of magnitude slower than the copy
+        weight = weight.contiguous()
     weight = weight.unflatten(-1, (-1,group_size))
     result = torch.matmul(weight, hadamard).flatten(-2,-1)
     del hadamard


### PR DESCRIPTION
A transposed activation view, which is what a transformer hands to sdpa, made the grouped hadamard matmul far slower than the copy it needs, and the quantizer copies the tensor right after anyway. MiniMax H3 at 9,316 tokens, 56 heads, head_dim 128, production options: 54 ms to 26 ms per attention call, the same as a contiguous input.