### PR TITLE
Feat/block mask

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ def sdpa_sdnq_atten(query: torch.FloatTensor, key: torch.FloatTensor, value: tor
 torch.nn.functional.scaled_dot_product_attention = sdpa_sdnq_atten
 ```
 
+Block-sparse attention (inference only): `sdnq_triton_atten` also takes `block_mask`, a bool or int8 tensor of shape `(batch or 1, heads or 1, ceil(QN / block_mask_m), ceil(KN / block_mask_n))` with `block_mask_m` and `block_mask_n` giving the block size in tokens. The kernel walks only the kept key blocks of each query block, the mask composes with `attn_mask`, and every autotune tile has to divide the block size (the default tile lists nest a 128x64 block).  
+
 
 ### Example code for quantized training:  
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ def sdpa_sdnq_atten(query: torch.FloatTensor, key: torch.FloatTensor, value: tor
 torch.nn.functional.scaled_dot_product_attention = sdpa_sdnq_atten
 ```
 
-Block-sparse attention (inference only): `sdnq_triton_atten` also takes `block_mask`, a bool or int8 tensor of shape `(batch or 1, heads or 1, ceil(QN / block_mask_m), ceil(KN / block_mask_n))` with `block_mask_m` and `block_mask_n` giving the block size in tokens. The kernel walks only the kept key blocks of each query block, the mask composes with `attn_mask`, and every autotune tile has to divide the block size (the default tile lists nest a 128x64 block).  
+Block-sparse attention: `sdnq_triton_atten` also takes `block_mask`, a bool or int8 tensor of shape `(batch or 1, heads or 1, ceil(QN / block_mask_m), ceil(KN / block_mask_n))` with `block_mask_m` and `block_mask_n` giving the block size in tokens. The kernel walks only the kept key blocks of each query block, the mask composes with `attn_mask`, and every autotune tile has to divide the block size (the default tile lists nest a 128x64 block). `sdnq_triton_atten_with_backward` takes the same three arguments and differentiates through the same selection.  
 
 
 ### Example code for quantized training:  

--- a/src/sdnq/kernels/triton_atten.py
+++ b/src/sdnq/kernels/triton_atten.py
@@ -262,11 +262,11 @@ def sdnq_attn_kernel(
         # load coordinate is chunk aligned
         tl.static_assert(BLOCK_MASK_M % BLOCK_SIZE_M == 0, "BLOCK_SIZE_M must divide BLOCK_MASK_M")
         tl.static_assert(BLOCK_MASK_N % BLOCK_SIZE_N == 0, "BLOCK_SIZE_N must divide BLOCK_MASK_N")
-        SUB_TILES: tl.constexpr = BLOCK_MASK_N // BLOCK_SIZE_N
-        NQB: tl.constexpr = (QN + BLOCK_MASK_M - 1) // BLOCK_MASK_M
-        NKB: tl.constexpr = (KN + BLOCK_MASK_N - 1) // BLOCK_MASK_N
-        NQB_PAD: tl.constexpr = ((NQB + BLOCK_COUNT_CHUNK - 1) // BLOCK_COUNT_CHUNK) * BLOCK_COUNT_CHUNK
-        NKB_PAD: tl.constexpr = ((NKB + BLOCK_INDEX_CHUNK - 1) // BLOCK_INDEX_CHUNK) * BLOCK_INDEX_CHUNK
+        SUB_TILES = BLOCK_MASK_N // BLOCK_SIZE_N
+        NQB = (QN + BLOCK_MASK_M - 1) // BLOCK_MASK_M
+        NKB = (KN + BLOCK_MASK_N - 1) // BLOCK_MASK_N
+        NQB_PAD = ((NQB + BLOCK_COUNT_CHUNK - 1) // BLOCK_COUNT_CHUNK) * BLOCK_COUNT_CHUNK
+        NKB_PAD = ((NKB + BLOCK_INDEX_CHUNK - 1) // BLOCK_INDEX_CHUNK) * BLOCK_INDEX_CHUNK
         q_block = start_m_block // BLOCK_MASK_M
         offset_lists = off_z_64 * (BH if BZ != 1 else 0) + (off_h_64 if BH != 1 else 0)
         count_desc = tl.make_tensor_descriptor(block_count_ptr + offset_lists * NQB_PAD, shape=[NQB_PAD], strides=[1,], block_shape=[BLOCK_COUNT_CHUNK])

--- a/src/sdnq/kernels/triton_atten.py
+++ b/src/sdnq/kernels/triton_atten.py
@@ -16,6 +16,8 @@ from ..utils import is_pow2, next_power_of_2, get_cache_sizes
 SDNQ_DEBUG_TRITON_AUTOTUNE = bool(os.environ.get("SDNQ_DEBUG_TRITON_AUTOTUNE", "0").lower() not in {"0", "false", "no"})
 
 min_block_size = int(os.environ.get("SDNQ_TRITON_ATTEN_MIN_BLOCK_SIZE", "256"))
+block_count_chunk = 4 # int32 entries per descriptor load of the block counts, 16 bytes
+block_index_chunk = 16 # int32 entries per descriptor load of the block index lists, 64 bytes
 autotune_configs = [
     triton.Config({"BLOCK_SIZE_M": BM, "BLOCK_SIZE_N": BN}, num_warps=w, num_stages=s)
     for BM in [int(BM) for BM in os.environ.get("SDNQ_TRITON_ATTEN_BLOCK_SIZE_M_LIST", "64,128").replace(" ","").split(",")]
@@ -30,6 +32,18 @@ small_autotune_configs = [
     for w in ([4,8] if torch.xpu.is_available() else [2,4])
     for s in ([1,] if (torch.cuda.is_available() and torch.version.hip) else [2,])
 ]
+
+
+def nest_block_mask_configs(configs: list[triton.Config], named_args: dict) -> list[triton.Config]:
+    # the block mask is read once per tile, so every tile has to sit inside a single mask block
+    if not named_args.get("do_block_mask"):
+        return configs
+    block_mask_m = named_args["BLOCK_MASK_M"]
+    block_mask_n = named_args["BLOCK_MASK_N"]
+    nested = [conf for conf in configs if (block_mask_m % conf.kwargs["BLOCK_SIZE_M"] == 0 and block_mask_n % conf.kwargs["BLOCK_SIZE_N"] == 0)]
+    if not nested:
+        raise ValueError(f"SDNQ Triton Atten: no autotune config nests the {block_mask_m}x{block_mask_n} block mask, check SDNQ_TRITON_ATTEN_BLOCK_SIZE_M_LIST and SDNQ_TRITON_ATTEN_BLOCK_SIZE_N_LIST")
+    return nested
 
 
 def prune_configs(configs: list[triton.Config], named_args: dict, from_small: bool = False, **kwargs): # pylint: disable=unused-argument
@@ -120,13 +134,13 @@ def prune_configs(configs: list[triton.Config], named_args: dict, from_small: bo
             if SDNQ_DEBUG_TRITON_AUTOTUNE:
                 shared.log.debug("SDNQ Triton Atten: No configs fit in cache/smem, trying small configs.")
             return prune_configs(small_autotune_configs, named_args, from_small=True, **kwargs)
-    return configs
+    return nest_block_mask_configs(configs, named_args)
 
 
 @triton.autotune(
     configs=autotune_configs,
     key=[
-        "is_causal", "do_mask",
+        "is_causal", "do_mask", "do_block_mask",
         "save_lse", "use_fp16_accum",
         "QZ", "QH", "QN_AT", "QHD",
         "KZ", "KH", "KN_AT", "KHD",
@@ -135,6 +149,7 @@ def prune_configs(configs: list[triton.Config], named_args: dict, from_small: bo
         "pv_is_quantized",
         "q_dtype", "v_dtype",
         "out_dtype", "mask_dtype",
+        "BLOCK_MASK_M", "BLOCK_MASK_N",
     ],
     prune_configs_by={'early_config_prune': prune_configs},
     cache_results=True,
@@ -143,15 +158,21 @@ def prune_configs(configs: list[triton.Config], named_args: dict, from_small: bo
 def sdnq_attn_kernel(
     q_ptr, k_ptr, v_ptr,
     q_scale_ptr, k_scale_ptr, v_scale_ptr,
-    out_ptr, lse_ptr, mask_ptr, sm_scale,
+    out_ptr, lse_ptr, mask_ptr, block_count_ptr, block_index_ptr, sm_scale,
     is_causal: tl.constexpr,
     do_mask: tl.constexpr,
+    do_block_mask: tl.constexpr,
     save_lse: tl.constexpr,
     use_fp16_accum: tl.constexpr,
     QZ: tl.constexpr, QH: tl.constexpr, QN: tl.constexpr, QHD: tl.constexpr,
     KZ: tl.constexpr, KH: tl.constexpr, KN: tl.constexpr, KHD: tl.constexpr,
     VZ: tl.constexpr, VH: tl.constexpr, VN: tl.constexpr, VHD: tl.constexpr,
     MZ: tl.constexpr, MH: tl.constexpr, MQN: tl.constexpr, MKN: tl.constexpr,
+    BLOCK_MASK_M: tl.constexpr,
+    BLOCK_MASK_N: tl.constexpr,
+    BLOCK_COUNT_CHUNK: tl.constexpr,
+    BLOCK_INDEX_CHUNK: tl.constexpr,
+    BZ: tl.constexpr, BH: tl.constexpr,
     QN_AT: tl.constexpr, # pylint: disable=unused-argument
     KN_AT: tl.constexpr, # pylint: disable=unused-argument
     VN_AT: tl.constexpr, # pylint: disable=unused-argument
@@ -184,6 +205,12 @@ def sdnq_attn_kernel(
     tl.assume(MH >= 0)
     tl.assume(MQN >= 0)
     tl.assume(MKN >= 0)
+    tl.assume(BLOCK_MASK_M >= 0)
+    tl.assume(BLOCK_MASK_N >= 0)
+    tl.assume(BLOCK_COUNT_CHUNK > 0)
+    tl.assume(BLOCK_INDEX_CHUNK > 0)
+    tl.assume(BZ >= 0)
+    tl.assume(BH >= 0)
     tl.assume(off_h >= 0)
     tl.assume(off_z >= 0)
     tl.assume(start_m >= 0)
@@ -191,6 +218,7 @@ def sdnq_attn_kernel(
     tl.assume(BLOCK_SIZE_N > 0)
     tl.assume(is_causal == 0 or is_causal == 1) # pylint: disable=consider-using-in
     tl.assume(do_mask == 0 or do_mask == 1) # pylint: disable=consider-using-in
+    tl.assume(do_block_mask == 0 or do_block_mask == 1) # pylint: disable=consider-using-in
     tl.assume(save_lse == 0 or save_lse == 1) # pylint: disable=consider-using-in
     tl.assume(use_fp16_accum == 0 or use_fp16_accum == 1) # pylint: disable=consider-using-in
     tl.assume(qk_is_quantized == 0 or qk_is_quantized == 1) # pylint: disable=consider-using-in
@@ -198,7 +226,11 @@ def sdnq_attn_kernel(
 
     sm_scale = sm_scale.to(tl.float32)
     log2_sm_scale = sm_scale * 1.4426950408889634
-    do_k_mask = KN % BLOCK_SIZE_N != 0
+    if do_block_mask:
+        # a ragged last mask block puts whole sub tiles past KN, which the tail rule has to cover even when the tile divides KN
+        do_k_mask = (KN % BLOCK_SIZE_N != 0) or (KN % BLOCK_MASK_N != 0)
+    else:
+        do_k_mask = KN % BLOCK_SIZE_N != 0
     start_m_block = start_m * BLOCK_SIZE_M
     offs_m = start_m_block + tl.arange(0, BLOCK_SIZE_M)
     offs_n = tl.arange(0, BLOCK_SIZE_N)
@@ -222,6 +254,29 @@ def sdnq_attn_kernel(
     if do_mask:
         offset_mask = off_z_64 * ((MQN * MH) if MZ != 1 else 0) + off_h_64 * (MQN if MH != 1 else 0)
         mask_desc = tl.make_tensor_descriptor(mask_ptr + offset_mask * MKN, shape=[QN, KN], strides=[(MKN if MQN != 1 else 0), 1], block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_N])
+    if do_block_mask:
+        # the loop walks only the kept kv blocks of this program's query block, in ascending order, so
+        # the body stays branch free and keeps its pipelining; every tile sits inside one mask block.
+        # The lists are contiguous, broadcast over batch and heads by shape like the token mask, and
+        # padded to the chunk sizes, so their descriptors need nothing beyond the shapes and every
+        # load coordinate is chunk aligned
+        tl.static_assert(BLOCK_MASK_M % BLOCK_SIZE_M == 0, "BLOCK_SIZE_M must divide BLOCK_MASK_M")
+        tl.static_assert(BLOCK_MASK_N % BLOCK_SIZE_N == 0, "BLOCK_SIZE_N must divide BLOCK_MASK_N")
+        SUB_TILES: tl.constexpr = BLOCK_MASK_N // BLOCK_SIZE_N
+        NQB: tl.constexpr = (QN + BLOCK_MASK_M - 1) // BLOCK_MASK_M
+        NKB: tl.constexpr = (KN + BLOCK_MASK_N - 1) // BLOCK_MASK_N
+        NQB_PAD: tl.constexpr = ((NQB + BLOCK_COUNT_CHUNK - 1) // BLOCK_COUNT_CHUNK) * BLOCK_COUNT_CHUNK
+        NKB_PAD: tl.constexpr = ((NKB + BLOCK_INDEX_CHUNK - 1) // BLOCK_INDEX_CHUNK) * BLOCK_INDEX_CHUNK
+        q_block = start_m_block // BLOCK_MASK_M
+        offset_lists = off_z_64 * (BH if BZ != 1 else 0) + (off_h_64 if BH != 1 else 0)
+        count_desc = tl.make_tensor_descriptor(block_count_ptr + offset_lists * NQB_PAD, shape=[NQB_PAD], strides=[1,], block_shape=[BLOCK_COUNT_CHUNK])
+        offs_count = tl.arange(0, BLOCK_COUNT_CHUNK)
+        counts = count_desc.load([(q_block // BLOCK_COUNT_CHUNK) * BLOCK_COUNT_CHUNK])
+        num_tiles = tl.sum(tl.where(offs_count == (q_block % BLOCK_COUNT_CHUNK), counts, 0)) * SUB_TILES
+        index_desc = tl.make_tensor_descriptor(block_index_ptr + (offset_lists * NQB + q_block) * NKB_PAD, shape=[NKB_PAD], strides=[1,], block_shape=[BLOCK_INDEX_CHUNK])
+        offs_index = tl.arange(0, BLOCK_INDEX_CHUNK)
+    else:
+        num_tiles = tl.cdiv(KN, BLOCK_SIZE_N)
 
     q = q_desc.load([start_m_block, 0])
     m_i = tl.full([BLOCK_SIZE_M], float("-inf"), dtype=tl.float32)
@@ -238,8 +293,16 @@ def sdnq_attn_kernel(
             fp16_scale_pv = 65536.0 * BLOCK_SIZE_N
             in_scale_pv = 1.0 / (65536.0 * BLOCK_SIZE_N)**0.5
 
-    for start_n_idx in tl.range(0, tl.cdiv(KN, BLOCK_SIZE_N)):
-        start_n = start_n_idx * BLOCK_SIZE_N
+    for tile in tl.range(0, num_tiles):
+        if do_block_mask:
+            # one chunk of the index list through the descriptor, the entry picked out by a masked reduction;
+            # a sub tile past the end of a ragged last block loads zeros and masks itself out below
+            block_pos = tile // SUB_TILES
+            chunk = index_desc.load([(block_pos // BLOCK_INDEX_CHUNK) * BLOCK_INDEX_CHUNK])
+            block_n = tl.sum(tl.where(offs_index == (block_pos % BLOCK_INDEX_CHUNK), chunk, 0))
+            start_n = block_n * BLOCK_MASK_N + (tile % SUB_TILES) * BLOCK_SIZE_N
+        else:
+            start_n = tile * BLOCK_SIZE_N
         skip = False
         if is_causal and ((start_m_block + BLOCK_SIZE_M) <= start_n):
             skip = True
@@ -347,10 +410,19 @@ def sdnq_atten_fwd(
     use_fp16_accum: bool = False,
     out_dtype: torch.dtype = torch.float32,
     return_lse: bool = False,
+    block_count: torch.Tensor | None = None,
+    block_index: torch.Tensor | None = None,
+    block_mask_m: int = 0,
+    block_mask_n: int = 0,
 )-> tuple[torch.Tensor, torch.Tensor | None]:
     QZ, QH, QN, _ = query.shape
     _, _, KN, _ = key.shape
     _, _, VN, VHD = value.shape
+    if block_count is not None or block_index is not None:
+        check_block_lists(block_count, block_index, QZ, QH, QN, KN, block_mask_m, block_mask_n)
+    else:
+        block_mask_m = 0
+        block_mask_n = 0
     def grid(META):
         return (triton.cdiv(QN, META["BLOCK_SIZE_M"]), QH, QZ)
     out = torch.empty((QZ, QH, QN, VHD), dtype=out_dtype, device=query.device)
@@ -358,13 +430,16 @@ def sdnq_atten_fwd(
     wrap_triton(sdnq_attn_kernel)[grid](
         query, key, value,
         query_scale, key_scale, value_scale,
-        out, lse, attn_mask, sm_scale,
+        out, lse, attn_mask, block_count, block_index, sm_scale,
         (1 if is_causal else 0),
         (1 if attn_mask is not None else 0),
+        (1 if block_count is not None else 0),
         (1 if return_lse else 0),
         (1 if use_fp16_accum else 0),
         *query.shape, *key.shape, *value.shape,
         *(attn_mask.shape if attn_mask is not None else (0, 0, 0, 0)),
+        block_mask_m, block_mask_n, block_count_chunk, block_index_chunk,
+        *(block_count.shape[:2] if block_count is not None else (0, 0)),
         math.ceil(QN / min_block_size),
         math.ceil(KN / min_block_size),
         math.ceil(VN / min_block_size),
@@ -390,6 +465,10 @@ def sdnq_triton_atten_fwd(
     sm_scale: float = 1.0,
     use_fp16_accum: bool = False,
     out_dtype: torch.dtype = torch.float32,
+    block_count: torch.Tensor | None = None,
+    block_index: torch.Tensor | None = None,
+    block_mask_m: int = 0,
+    block_mask_n: int = 0,
 ) -> torch.Tensor:
     return sdnq_atten_fwd(
         query, key, value,
@@ -400,6 +479,10 @@ def sdnq_triton_atten_fwd(
         use_fp16_accum=use_fp16_accum,
         out_dtype=out_dtype,
         return_lse=False,
+        block_count=block_count,
+        block_index=block_index,
+        block_mask_m=block_mask_m,
+        block_mask_n=block_mask_n,
     )[0]
 
 
@@ -417,6 +500,10 @@ def sdnq_triton_atten_lse_fwd(
     sm_scale: float = 1.0,
     use_fp16_accum: bool = False,
     out_dtype: torch.dtype = torch.float32,
+    block_count: torch.Tensor | None = None,
+    block_index: torch.Tensor | None = None,
+    block_mask_m: int = 0,
+    block_mask_n: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     return sdnq_atten_fwd(
         query, key, value,
@@ -427,6 +514,10 @@ def sdnq_triton_atten_lse_fwd(
         use_fp16_accum=use_fp16_accum,
         out_dtype=out_dtype,
         return_lse=True,
+        block_count=block_count,
+        block_index=block_index,
+        block_mask_m=block_mask_m,
+        block_mask_n=block_mask_n,
     )
 
 
@@ -527,6 +618,49 @@ def get_attn_inputs(
     return query, query_scale, key, key_scale, value, value_scale, attn_mask, sm_scale, out_dtype, use_hadamard, hadamard_group_size
 
 
+def get_block_list_dims(rows: int, cols: int, row_block: int, col_block: int) -> tuple[int, int, int, int]:
+    # the kernel reads both lists through descriptors in fixed chunks, so their last dims are padded to the chunk sizes
+    row_blocks = triton.cdiv(rows, row_block)
+    col_blocks = triton.cdiv(cols, col_block)
+    return row_blocks, triton.cdiv(row_blocks, block_count_chunk) * block_count_chunk, col_blocks, triton.cdiv(col_blocks, block_index_chunk) * block_index_chunk
+
+
+def check_block_lists(block_count: torch.Tensor | None, block_index: torch.Tensor | None, batch: int, heads: int, rows: int, cols: int, row_block: int, col_block: int) -> None:
+    # per row block: how many column blocks are kept, and their indices in ascending order; contiguous, batch and head
+    # dims of size 1 broadcast, padded to the chunk sizes (get_block_mask_input builds both from an int8 mask). The
+    # backward's dkv pass hands the transposed geometry, so rows and columns are named rather than fixed to q and kv
+    if block_count is None or block_index is None:
+        raise ValueError("SDNQ Triton Atten: block_count and block_index go together")
+    if block_count.ndim != 3 or block_count.dtype != torch.int32 or block_index.ndim != 4 or block_index.dtype != torch.int32:
+        raise ValueError(f"SDNQ Triton Atten: block_count must be a 3D int32 tensor and block_index a 4D int32 tensor, got {block_count.ndim}D {block_count.dtype} and {block_index.ndim}D {block_index.dtype}")
+    if row_block <= 0 or col_block <= 0:
+        raise ValueError("SDNQ Triton Atten: a block mask needs block_mask_m and block_mask_n")
+    if not block_count.is_contiguous() or not block_index.is_contiguous():
+        raise ValueError("SDNQ Triton Atten: block_count and block_index must be contiguous")
+    row_blocks, row_blocks_pad, col_blocks, col_blocks_pad = get_block_list_dims(rows, cols, row_block, col_block)
+    if block_count.shape[0] not in {1, batch} or block_count.shape[1] not in {1, heads} or block_count.shape[2] != row_blocks_pad or tuple(block_index.shape) != (*block_count.shape[:2], row_blocks, col_blocks_pad):
+        raise ValueError(f"SDNQ Triton Atten: block_count {tuple(block_count.shape)} and block_index {tuple(block_index.shape)} do not match ({batch} or 1, {heads} or 1, {row_blocks_pad}) and (..., {row_blocks}, {col_blocks_pad}) for a {row_block}x{col_block} block over {rows}x{cols}")
+
+
+@devices.inference_context()
+def get_block_mask_input(block_mask: torch.Tensor, batch: int, heads: int) -> tuple[torch.Tensor, torch.Tensor]:
+    # the kernel walks the kept kv blocks of each query block, so the mask becomes a count and an ascending
+    # index list per row, the form FlexAttention's BlockMask holds too, batch and head dims kept as given
+    # (size 1 broadcasts) and padded to the descriptor chunks; kept out of get_attn_inputs so the compiled
+    # input prep does not gain a specialization axis
+    while block_mask.ndim < 4:
+        block_mask = block_mask.unsqueeze(0)
+    if block_mask.shape[0] not in {1, batch} or block_mask.shape[1] not in {1, heads}:
+        raise ValueError(f"SDNQ Triton Atten: block_mask {tuple(block_mask.shape)} does not broadcast over batch={batch} heads={heads}")
+    keep = block_mask != 0
+    nqb, nkb = keep.shape[-2:]
+    block_count = keep.sum(dim=-1, dtype=torch.int32)
+    block_count = torch.nn.functional.pad(block_count, (0, triton.cdiv(nqb, block_count_chunk) * block_count_chunk - nqb))
+    block_index = torch.argsort(keep.to(dtype=torch.int8), dim=-1, descending=True, stable=True).to(dtype=torch.int32)
+    block_index = torch.nn.functional.pad(block_index, (0, triton.cdiv(nkb, block_index_chunk) * block_index_chunk - nkb))
+    return block_count.contiguous(), block_index.contiguous()
+
+
 @devices.inference_context()
 def sdnq_triton_atten(
     query: torch.Tensor,
@@ -546,10 +680,19 @@ def sdnq_triton_atten(
     use_fp16_accum: bool = False,
     out_dtype: torch.dtype | None = None,
     return_backward: bool = False,
+    block_mask: torch.Tensor | None = None,
+    block_mask_m: int = 0,
+    block_mask_n: int = 0,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, float, bool, int]:
     QHD = query.shape[-1]
     KHD = key.shape[-1]
     VHD = value.shape[-1]
+
+    block_count = block_index = None
+    if block_mask is not None:
+        if return_backward:
+            raise NotImplementedError("SDNQ Triton Atten: block_mask has no backward")
+        block_count, block_index = get_block_mask_input(block_mask, query.shape[0], query.shape[1])
 
     hadamard = None
     if use_hadamard and do_quantize and matmul_dtype not in {None, "none", "no", "disabled"}:
@@ -594,6 +737,10 @@ def sdnq_triton_atten(
             sm_scale=sm_scale,
             use_fp16_accum=use_fp16_accum,
             out_dtype=out_dtype,
+            block_count=block_count,
+            block_index=block_index,
+            block_mask_m=block_mask_m,
+            block_mask_n=block_mask_n,
         )
 
     if use_hadamard and pv_matmul_dtype not in {None, "auto", "none", "no", "disabled"}:

--- a/src/sdnq/kernels/triton_atten.py
+++ b/src/sdnq/kernels/triton_atten.py
@@ -690,8 +690,6 @@ def sdnq_triton_atten(
 
     block_count = block_index = None
     if block_mask is not None:
-        if return_backward:
-            raise NotImplementedError("SDNQ Triton Atten: block_mask has no backward")
         block_count, block_index = get_block_mask_input(block_mask, query.shape[0], query.shape[1])
 
     hadamard = None
@@ -727,6 +725,10 @@ def sdnq_triton_atten(
             sm_scale=sm_scale,
             use_fp16_accum=use_fp16_accum,
             out_dtype=out_dtype,
+            block_count=block_count,
+            block_index=block_index,
+            block_mask_m=block_mask_m,
+            block_mask_n=block_mask_n,
         )
     else:
         out = sdnq_triton_atten_fwd(

--- a/src/sdnq/kernels/triton_atten_backward.py
+++ b/src/sdnq/kernels/triton_atten_backward.py
@@ -136,11 +136,11 @@ def sdnq_attn_bwd_dq_kernel(
         # dq walks the same kv blocks the forward walked for this query block, so it reads the forward's lists unchanged
         tl.static_assert(BLOCK_MASK_M % BLOCK_SIZE_M == 0, "BLOCK_SIZE_M must divide BLOCK_MASK_M")
         tl.static_assert(BLOCK_MASK_N % BLOCK_SIZE_N == 0, "BLOCK_SIZE_N must divide BLOCK_MASK_N")
-        SUB_TILES: tl.constexpr = BLOCK_MASK_N // BLOCK_SIZE_N
-        NQB: tl.constexpr = (QN + BLOCK_MASK_M - 1) // BLOCK_MASK_M
-        NKB: tl.constexpr = (KN + BLOCK_MASK_N - 1) // BLOCK_MASK_N
-        NQB_PAD: tl.constexpr = ((NQB + BLOCK_COUNT_CHUNK - 1) // BLOCK_COUNT_CHUNK) * BLOCK_COUNT_CHUNK
-        NKB_PAD: tl.constexpr = ((NKB + BLOCK_INDEX_CHUNK - 1) // BLOCK_INDEX_CHUNK) * BLOCK_INDEX_CHUNK
+        SUB_TILES = BLOCK_MASK_N // BLOCK_SIZE_N
+        NQB = (QN + BLOCK_MASK_M - 1) // BLOCK_MASK_M
+        NKB = (KN + BLOCK_MASK_N - 1) // BLOCK_MASK_N
+        NQB_PAD = ((NQB + BLOCK_COUNT_CHUNK - 1) // BLOCK_COUNT_CHUNK) * BLOCK_COUNT_CHUNK
+        NKB_PAD = ((NKB + BLOCK_INDEX_CHUNK - 1) // BLOCK_INDEX_CHUNK) * BLOCK_INDEX_CHUNK
         q_block = start_m_block // BLOCK_MASK_M
         offset_lists = off_z_64 * (BH if BZ != 1 else 0) + (off_h_64 if BH != 1 else 0)
         count_desc = tl.make_tensor_descriptor(block_count_ptr + offset_lists * NQB_PAD, shape=[NQB_PAD], strides=[1,], block_shape=[BLOCK_COUNT_CHUNK])
@@ -425,11 +425,11 @@ def sdnq_attn_bwd_dkv_kernel(
             # which contribute nothing to either gradient, and a causally dead tile is scored to -inf as before
             tl.static_assert(BLOCK_MASK_M % BLOCK_SIZE_M == 0, "BLOCK_SIZE_M must divide BLOCK_MASK_M")
             tl.static_assert(BLOCK_MASK_N % BLOCK_SIZE_N == 0, "BLOCK_SIZE_N must divide BLOCK_MASK_N")
-            SUB_TILES: tl.constexpr = BLOCK_MASK_M // BLOCK_SIZE_M
-            NQB: tl.constexpr = (QN + BLOCK_MASK_M - 1) // BLOCK_MASK_M
-            NKB: tl.constexpr = (KN + BLOCK_MASK_N - 1) // BLOCK_MASK_N
-            NKB_PAD: tl.constexpr = ((NKB + BLOCK_COUNT_CHUNK - 1) // BLOCK_COUNT_CHUNK) * BLOCK_COUNT_CHUNK
-            NQB_PAD: tl.constexpr = ((NQB + BLOCK_INDEX_CHUNK - 1) // BLOCK_INDEX_CHUNK) * BLOCK_INDEX_CHUNK
+            SUB_TILES = BLOCK_MASK_M // BLOCK_SIZE_M
+            NQB = (QN + BLOCK_MASK_M - 1) // BLOCK_MASK_M
+            NKB = (KN + BLOCK_MASK_N - 1) // BLOCK_MASK_N
+            NKB_PAD = ((NKB + BLOCK_COUNT_CHUNK - 1) // BLOCK_COUNT_CHUNK) * BLOCK_COUNT_CHUNK
+            NQB_PAD = ((NQB + BLOCK_INDEX_CHUNK - 1) // BLOCK_INDEX_CHUNK) * BLOCK_INDEX_CHUNK
             kv_block = start_n_block // BLOCK_MASK_N
             offset_lists = off_z_64 * (BH if BZ != 1 else 0) + (off_h_64 if BH != 1 else 0)
             count_desc = tl.make_tensor_descriptor(block_count_ptr + offset_lists * NKB_PAD, shape=[NKB_PAD], strides=[1,], block_shape=[BLOCK_COUNT_CHUNK])

--- a/src/sdnq/kernels/triton_atten_backward.py
+++ b/src/sdnq/kernels/triton_atten_backward.py
@@ -9,13 +9,13 @@ import triton.language as tl
 from ..sdnext import devices
 from ..common import compile_func
 from ..quant_utils import quantize_int_mm, quantize_fp_mm, get_hadamard, rotate_hadamard, rotate_hadamard_compiled
-from .triton_atten import sdnq_triton_atten, autotune_configs, min_block_size, prune_configs
+from .triton_atten import sdnq_triton_atten, autotune_configs, min_block_size, prune_configs, block_count_chunk, block_index_chunk, get_block_mask_input, check_block_lists
 
 
 @triton.autotune(
     configs=autotune_configs,
     key=[
-        "is_causal", "do_mask",
+        "is_causal", "do_mask", "do_block_mask",
         "use_fp16_accum",
         "QZ", "QH", "QN_AT", "QHD",
         "KZ", "KH", "KN_AT", "KHD",
@@ -24,6 +24,7 @@ from .triton_atten import sdnq_triton_atten, autotune_configs, min_block_size, p
         "pv_is_quantized",
         "q_dtype", "v_dtype",
         "out_dtype", "mask_dtype",
+        "BLOCK_MASK_M", "BLOCK_MASK_N",
     ],
     prune_configs_by={'early_config_prune': prune_configs},
     cache_results=True,
@@ -32,14 +33,20 @@ from .triton_atten import sdnq_triton_atten, autotune_configs, min_block_size, p
 def sdnq_attn_bwd_dq_kernel(
     q_ptr, k_ptr, v_ptr, do_ptr,
     q_scale_ptr, k_scale_ptr, v_scale_ptr, do_scale_ptr,
-    dq_ptr, lse_ptr, delta_ptr, mask_ptr, sm_scale,
+    dq_ptr, lse_ptr, delta_ptr, mask_ptr, block_count_ptr, block_index_ptr, sm_scale,
     is_causal: tl.constexpr,
     do_mask: tl.constexpr,
+    do_block_mask: tl.constexpr,
     use_fp16_accum: tl.constexpr,
     QZ: tl.constexpr, QH: tl.constexpr, QN: tl.constexpr, QHD: tl.constexpr,
     KZ: tl.constexpr, KH: tl.constexpr, KN: tl.constexpr, KHD: tl.constexpr,
     VZ: tl.constexpr, VH: tl.constexpr, VN: tl.constexpr, VHD: tl.constexpr,
     MZ: tl.constexpr, MH: tl.constexpr, MQN: tl.constexpr, MKN: tl.constexpr,
+    BLOCK_MASK_M: tl.constexpr,
+    BLOCK_MASK_N: tl.constexpr,
+    BLOCK_COUNT_CHUNK: tl.constexpr,
+    BLOCK_INDEX_CHUNK: tl.constexpr,
+    BZ: tl.constexpr, BH: tl.constexpr,
     QN_AT: tl.constexpr, # pylint: disable=unused-argument
     KN_AT: tl.constexpr, # pylint: disable=unused-argument
     VN_AT: tl.constexpr, # pylint: disable=unused-argument
@@ -72,6 +79,12 @@ def sdnq_attn_bwd_dq_kernel(
     tl.assume(MH >= 0)
     tl.assume(MQN >= 0)
     tl.assume(MKN >= 0)
+    tl.assume(BLOCK_MASK_M >= 0)
+    tl.assume(BLOCK_MASK_N >= 0)
+    tl.assume(BLOCK_COUNT_CHUNK > 0)
+    tl.assume(BLOCK_INDEX_CHUNK > 0)
+    tl.assume(BZ >= 0)
+    tl.assume(BH >= 0)
     tl.assume(off_h >= 0)
     tl.assume(off_z >= 0)
     tl.assume(start_m >= 0)
@@ -79,13 +92,18 @@ def sdnq_attn_bwd_dq_kernel(
     tl.assume(BLOCK_SIZE_N > 0)
     tl.assume(is_causal == 0 or is_causal == 1) # pylint: disable=consider-using-in
     tl.assume(do_mask == 0 or do_mask == 1) # pylint: disable=consider-using-in
+    tl.assume(do_block_mask == 0 or do_block_mask == 1) # pylint: disable=consider-using-in
     tl.assume(use_fp16_accum == 0 or use_fp16_accum == 1) # pylint: disable=consider-using-in
     tl.assume(qk_is_quantized == 0 or qk_is_quantized == 1) # pylint: disable=consider-using-in
     tl.assume(pv_is_quantized == 0 or pv_is_quantized == 1) # pylint: disable=consider-using-in
 
     sm_scale = sm_scale.to(tl.float32)
     log2_sm_scale = sm_scale * 1.4426950408889634
-    do_k_mask = KN % BLOCK_SIZE_N != 0
+    if do_block_mask:
+        # a ragged last mask block puts whole sub tiles past KN, which the tail rule has to cover even when the tile divides KN
+        do_k_mask = (KN % BLOCK_SIZE_N != 0) or (KN % BLOCK_MASK_N != 0)
+    else:
+        do_k_mask = KN % BLOCK_SIZE_N != 0
     start_m_block = start_m * BLOCK_SIZE_M
     offs_m = start_m_block + tl.arange(0, BLOCK_SIZE_M)
     offs_n = tl.arange(0, BLOCK_SIZE_N)
@@ -114,6 +132,25 @@ def sdnq_attn_bwd_dq_kernel(
     if do_mask:
         offset_mask = off_z_64 * ((MQN * MH) if MZ != 1 else 0) + off_h_64 * (MQN if MH != 1 else 0)
         mask_desc = tl.make_tensor_descriptor(mask_ptr + offset_mask * MKN, shape=[QN, KN], strides=[(MKN if MQN != 1 else 0), 1], block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_N])
+    if do_block_mask:
+        # dq walks the same kv blocks the forward walked for this query block, so it reads the forward's lists unchanged
+        tl.static_assert(BLOCK_MASK_M % BLOCK_SIZE_M == 0, "BLOCK_SIZE_M must divide BLOCK_MASK_M")
+        tl.static_assert(BLOCK_MASK_N % BLOCK_SIZE_N == 0, "BLOCK_SIZE_N must divide BLOCK_MASK_N")
+        SUB_TILES: tl.constexpr = BLOCK_MASK_N // BLOCK_SIZE_N
+        NQB: tl.constexpr = (QN + BLOCK_MASK_M - 1) // BLOCK_MASK_M
+        NKB: tl.constexpr = (KN + BLOCK_MASK_N - 1) // BLOCK_MASK_N
+        NQB_PAD: tl.constexpr = ((NQB + BLOCK_COUNT_CHUNK - 1) // BLOCK_COUNT_CHUNK) * BLOCK_COUNT_CHUNK
+        NKB_PAD: tl.constexpr = ((NKB + BLOCK_INDEX_CHUNK - 1) // BLOCK_INDEX_CHUNK) * BLOCK_INDEX_CHUNK
+        q_block = start_m_block // BLOCK_MASK_M
+        offset_lists = off_z_64 * (BH if BZ != 1 else 0) + (off_h_64 if BH != 1 else 0)
+        count_desc = tl.make_tensor_descriptor(block_count_ptr + offset_lists * NQB_PAD, shape=[NQB_PAD], strides=[1,], block_shape=[BLOCK_COUNT_CHUNK])
+        offs_count = tl.arange(0, BLOCK_COUNT_CHUNK)
+        counts = count_desc.load([(q_block // BLOCK_COUNT_CHUNK) * BLOCK_COUNT_CHUNK])
+        num_tiles = tl.sum(tl.where(offs_count == (q_block % BLOCK_COUNT_CHUNK), counts, 0)) * SUB_TILES
+        index_desc = tl.make_tensor_descriptor(block_index_ptr + (offset_lists * NQB + q_block) * NKB_PAD, shape=[NKB_PAD], strides=[1,], block_shape=[BLOCK_INDEX_CHUNK])
+        offs_index = tl.arange(0, BLOCK_INDEX_CHUNK)
+    else:
+        num_tiles = tl.cdiv(KN, BLOCK_SIZE_N)
 
     q = q_desc.load([start_m_block, 0])
     do = do_desc.load([start_m_block, 0])
@@ -135,8 +172,14 @@ def sdnq_attn_bwd_dq_kernel(
             do = tl.mul(do.to(tl.float32), in_scale_pv).to(tl.float16)
             do_scale = tl.mul(do_scale, fp16_scale_pv)
 
-    for start_n_idx in tl.range(0, tl.cdiv(KN, BLOCK_SIZE_N)):
-        start_n = start_n_idx * BLOCK_SIZE_N
+    for tile in tl.range(0, num_tiles):
+        if do_block_mask:
+            block_pos = tile // SUB_TILES
+            chunk = index_desc.load([(block_pos // BLOCK_INDEX_CHUNK) * BLOCK_INDEX_CHUNK])
+            block_n = tl.sum(tl.where(offs_index == (block_pos % BLOCK_INDEX_CHUNK), chunk, 0))
+            start_n = block_n * BLOCK_MASK_N + (tile % SUB_TILES) * BLOCK_SIZE_N
+        else:
+            start_n = tile * BLOCK_SIZE_N
         skip = False
         if is_causal and ((start_m_block + BLOCK_SIZE_M) <= start_n):
             skip = True
@@ -226,7 +269,7 @@ def sdnq_attn_bwd_dq_kernel(
     configs=autotune_configs,
     key=[
         "do_grad_k", "do_grad_v",
-        "is_causal", "do_mask",
+        "is_causal", "do_mask", "do_block_mask",
         "use_fp16_accum",
         "QZ", "QH", "QN_AT", "QHD",
         "KZ", "KH", "KN_AT", "KHD",
@@ -235,6 +278,7 @@ def sdnq_attn_bwd_dq_kernel(
         "pv_is_quantized",
         "q_dtype", "v_dtype",
         "out_dtype", "mask_dtype",
+        "BLOCK_MASK_M", "BLOCK_MASK_N",
     ],
     prune_configs_by={'early_config_prune': prune_configs},
     cache_results=True,
@@ -243,16 +287,22 @@ def sdnq_attn_bwd_dq_kernel(
 def sdnq_attn_bwd_dkv_kernel(
     q_ptr, k_ptr, v_ptr, do_ptr,
     q_scale_ptr, k_scale_ptr, v_scale_ptr, do_scale_ptr,
-    dk_ptr, dv_ptr, lse_ptr, delta_ptr, mask_ptr, sm_scale,
+    dk_ptr, dv_ptr, lse_ptr, delta_ptr, mask_ptr, block_count_ptr, block_index_ptr, sm_scale,
     do_grad_k: tl.constexpr,
     do_grad_v: tl.constexpr,
     is_causal: tl.constexpr,
     do_mask: tl.constexpr,
+    do_block_mask: tl.constexpr,
     use_fp16_accum: tl.constexpr,
     QZ: tl.constexpr, QH: tl.constexpr, QN: tl.constexpr, QHD: tl.constexpr,
     KZ: tl.constexpr, KH: tl.constexpr, KN: tl.constexpr, KHD: tl.constexpr,
     VZ: tl.constexpr, VH: tl.constexpr, VN: tl.constexpr, VHD: tl.constexpr,
     MZ: tl.constexpr, MH: tl.constexpr, MQN: tl.constexpr, MKN: tl.constexpr,
+    BLOCK_MASK_M: tl.constexpr,
+    BLOCK_MASK_N: tl.constexpr,
+    BLOCK_COUNT_CHUNK: tl.constexpr,
+    BLOCK_INDEX_CHUNK: tl.constexpr,
+    BZ: tl.constexpr, BH: tl.constexpr,
     QN_AT: tl.constexpr, # pylint: disable=unused-argument
     KN_AT: tl.constexpr, # pylint: disable=unused-argument
     VN_AT: tl.constexpr, # pylint: disable=unused-argument
@@ -285,11 +335,18 @@ def sdnq_attn_bwd_dkv_kernel(
     tl.assume(MH >= 0)
     tl.assume(MQN >= 0)
     tl.assume(MKN >= 0)
+    tl.assume(BLOCK_MASK_M >= 0)
+    tl.assume(BLOCK_MASK_N >= 0)
+    tl.assume(BLOCK_COUNT_CHUNK > 0)
+    tl.assume(BLOCK_INDEX_CHUNK > 0)
+    tl.assume(BZ >= 0)
+    tl.assume(BH >= 0)
     tl.assume(off_z >= 0)
     tl.assume(BLOCK_SIZE_M > 0)
     tl.assume(BLOCK_SIZE_N > 0)
     tl.assume(is_causal == 0 or is_causal == 1) # pylint: disable=consider-using-in
     tl.assume(do_mask == 0 or do_mask == 1) # pylint: disable=consider-using-in
+    tl.assume(do_block_mask == 0 or do_block_mask == 1) # pylint: disable=consider-using-in
     tl.assume(use_fp16_accum == 0 or use_fp16_accum == 1) # pylint: disable=consider-using-in
     tl.assume(qk_is_quantized == 0 or qk_is_quantized == 1) # pylint: disable=consider-using-in
     tl.assume(pv_is_quantized == 0 or pv_is_quantized == 1) # pylint: disable=consider-using-in
@@ -362,8 +419,36 @@ def sdnq_attn_bwd_dkv_kernel(
         else:
             start_m_idx_start = 0
 
-        for start_m_idx in tl.range(start_m_idx_start, tl.cdiv(QN, BLOCK_SIZE_M)):
-            start_m = start_m_idx * BLOCK_SIZE_M
+        if do_block_mask:
+            # dkv walks the query blocks that kept this kv block, so it reads the mask transposed: a count and an
+            # ascending index list per kv block. A query tile past a ragged last block loads zeros for q and do,
+            # which contribute nothing to either gradient, and a causally dead tile is scored to -inf as before
+            tl.static_assert(BLOCK_MASK_M % BLOCK_SIZE_M == 0, "BLOCK_SIZE_M must divide BLOCK_MASK_M")
+            tl.static_assert(BLOCK_MASK_N % BLOCK_SIZE_N == 0, "BLOCK_SIZE_N must divide BLOCK_MASK_N")
+            SUB_TILES: tl.constexpr = BLOCK_MASK_M // BLOCK_SIZE_M
+            NQB: tl.constexpr = (QN + BLOCK_MASK_M - 1) // BLOCK_MASK_M
+            NKB: tl.constexpr = (KN + BLOCK_MASK_N - 1) // BLOCK_MASK_N
+            NKB_PAD: tl.constexpr = ((NKB + BLOCK_COUNT_CHUNK - 1) // BLOCK_COUNT_CHUNK) * BLOCK_COUNT_CHUNK
+            NQB_PAD: tl.constexpr = ((NQB + BLOCK_INDEX_CHUNK - 1) // BLOCK_INDEX_CHUNK) * BLOCK_INDEX_CHUNK
+            kv_block = start_n_block // BLOCK_MASK_N
+            offset_lists = off_z_64 * (BH if BZ != 1 else 0) + (off_h_64 if BH != 1 else 0)
+            count_desc = tl.make_tensor_descriptor(block_count_ptr + offset_lists * NKB_PAD, shape=[NKB_PAD], strides=[1,], block_shape=[BLOCK_COUNT_CHUNK])
+            offs_count = tl.arange(0, BLOCK_COUNT_CHUNK)
+            counts = count_desc.load([(kv_block // BLOCK_COUNT_CHUNK) * BLOCK_COUNT_CHUNK])
+            num_tiles = tl.sum(tl.where(offs_count == (kv_block % BLOCK_COUNT_CHUNK), counts, 0)) * SUB_TILES
+            index_desc = tl.make_tensor_descriptor(block_index_ptr + (offset_lists * NKB + kv_block) * NQB_PAD, shape=[NQB_PAD], strides=[1,], block_shape=[BLOCK_INDEX_CHUNK])
+            offs_index = tl.arange(0, BLOCK_INDEX_CHUNK)
+        else:
+            num_tiles = tl.cdiv(QN, BLOCK_SIZE_M) - start_m_idx_start
+
+        for tile in tl.range(0, num_tiles):
+            if do_block_mask:
+                block_pos = tile // SUB_TILES
+                chunk = index_desc.load([(block_pos // BLOCK_INDEX_CHUNK) * BLOCK_INDEX_CHUNK])
+                block_m = tl.sum(tl.where(offs_index == (block_pos % BLOCK_INDEX_CHUNK), chunk, 0))
+                start_m = block_m * BLOCK_MASK_M + (tile % SUB_TILES) * BLOCK_SIZE_M
+            else:
+                start_m = (start_m_idx_start + tile) * BLOCK_SIZE_M
             skip = False
             if do_mask:
                 mask = mask_desc.load([start_m, start_n_block])
@@ -499,22 +584,34 @@ def sdnq_triton_atten_bwd_dq(
     is_causal: bool = False,
     use_fp16_accum: bool = False,
     out_dtype: torch.dtype | None = None,
+    block_count: torch.Tensor | None = None,
+    block_index: torch.Tensor | None = None,
+    block_mask_m: int = 0,
+    block_mask_n: int = 0,
 ) -> torch.Tensor:
     QZ, QH, QN, _ = query.shape
     _, _, KN, _ = key.shape
     _, _, VN, _ = value.shape
+    if block_count is not None or block_index is not None:
+        check_block_lists(block_count, block_index, QZ, QH, QN, KN, block_mask_m, block_mask_n)
+    else:
+        block_mask_m = 0
+        block_mask_n = 0
     def grid_dq(META):
         return (triton.cdiv(QN, META["BLOCK_SIZE_M"]), QH, QZ)
     dq = torch.empty_like(query, dtype=out_dtype)
     wrap_triton(sdnq_attn_bwd_dq_kernel)[grid_dq](
         query, key, value, grad_output,
         query_scale, key_scale, value_scale, grad_output_scale,
-        dq, lse, delta, attn_mask, sm_scale,
+        dq, lse, delta, attn_mask, block_count, block_index, sm_scale,
         (1 if is_causal else 0),
         (1 if attn_mask is not None else 0),
+        (1 if block_count is not None else 0),
         (1 if use_fp16_accum else 0),
         *query.shape, *key.shape, *value.shape,
         *(attn_mask.shape if attn_mask is not None else (0, 0, 0, 0)),
+        block_mask_m, block_mask_n, block_count_chunk, block_index_chunk,
+        *(block_count.shape[:2] if block_count is not None else (0, 0)),
         math.ceil(QN / min_block_size),
         math.ceil(KN / min_block_size),
         math.ceil(VN / min_block_size),
@@ -545,10 +642,20 @@ def sdnq_atten_bwd_dkv(
     out_dtype: torch.dtype | None = None,
     do_grad_k: bool = True,
     do_grad_v: bool = True,
+    block_count: torch.Tensor | None = None,
+    block_index: torch.Tensor | None = None,
+    block_mask_m: int = 0,
+    block_mask_n: int = 0,
 ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
-    QZ, _, QN, _ = query.shape
+    QZ, QH, QN, _ = query.shape
     _, KH, KN, _ = key.shape
     _, _, VN, _ = value.shape
+    if block_count is not None or block_index is not None:
+        # the transposed geometry: rows are kv blocks and the lists name the query blocks that kept them
+        check_block_lists(block_count, block_index, QZ, QH, KN, QN, block_mask_n, block_mask_m)
+    else:
+        block_mask_m = 0
+        block_mask_n = 0
     def grid_dkv(META):
         return (triton.cdiv(KN, META["BLOCK_SIZE_N"]), KH, QZ)
     dk = torch.empty_like(key, dtype=out_dtype) if do_grad_k else None
@@ -556,14 +663,17 @@ def sdnq_atten_bwd_dkv(
     wrap_triton(sdnq_attn_bwd_dkv_kernel)[grid_dkv](
         query, key, value, grad_output,
         query_scale, key_scale, value_scale, grad_output_scale,
-        dk, dv, lse, delta, attn_mask, sm_scale,
+        dk, dv, lse, delta, attn_mask, block_count, block_index, sm_scale,
         (1 if do_grad_k else 0),
         (1 if do_grad_v else 0),
         (1 if is_causal else 0),
         (1 if attn_mask is not None else 0),
+        (1 if block_count is not None else 0),
         (1 if use_fp16_accum else 0),
         *query.shape, *key.shape, *value.shape,
         *(attn_mask.shape if attn_mask is not None else (0, 0, 0, 0)),
+        block_mask_m, block_mask_n, block_count_chunk, block_index_chunk,
+        *(block_count.shape[:2] if block_count is not None else (0, 0)),
         math.ceil(QN / min_block_size),
         math.ceil(KN / min_block_size),
         math.ceil(VN / min_block_size),
@@ -593,6 +703,10 @@ def sdnq_triton_atten_bwd_dkv(
     is_causal: bool = False,
     use_fp16_accum: bool = False,
     out_dtype: torch.dtype | None = None,
+    block_count: torch.Tensor | None = None,
+    block_index: torch.Tensor | None = None,
+    block_mask_m: int = 0,
+    block_mask_n: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     return sdnq_atten_bwd_dkv(
         grad_output, delta, lse,
@@ -608,6 +722,10 @@ def sdnq_triton_atten_bwd_dkv(
         out_dtype=out_dtype,
         do_grad_k=True,
         do_grad_v=True,
+        block_count=block_count,
+        block_index=block_index,
+        block_mask_m=block_mask_m,
+        block_mask_n=block_mask_n,
     )
 
 
@@ -629,6 +747,10 @@ def sdnq_triton_atten_bwd_dk(
     is_causal: bool = False,
     use_fp16_accum: bool = False,
     out_dtype: torch.dtype | None = None,
+    block_count: torch.Tensor | None = None,
+    block_index: torch.Tensor | None = None,
+    block_mask_m: int = 0,
+    block_mask_n: int = 0,
 ) -> torch.Tensor:
     return sdnq_atten_bwd_dkv(
         grad_output, delta, lse,
@@ -644,6 +766,10 @@ def sdnq_triton_atten_bwd_dk(
         out_dtype=out_dtype,
         do_grad_k=True,
         do_grad_v=False,
+        block_count=block_count,
+        block_index=block_index,
+        block_mask_m=block_mask_m,
+        block_mask_n=block_mask_n,
     )[0]
 
 
@@ -665,6 +791,10 @@ def sdnq_triton_atten_bwd_dv(
     is_causal: bool = False,
     use_fp16_accum: bool = False,
     out_dtype: torch.dtype | None = None,
+    block_count: torch.Tensor | None = None,
+    block_index: torch.Tensor | None = None,
+    block_mask_m: int = 0,
+    block_mask_n: int = 0,
 ) -> torch.Tensor:
     return sdnq_atten_bwd_dkv(
         grad_output, delta, lse,
@@ -680,6 +810,10 @@ def sdnq_triton_atten_bwd_dv(
         out_dtype=out_dtype,
         do_grad_k=False,
         do_grad_v=True,
+        block_count=block_count,
+        block_index=block_index,
+        block_mask_m=block_mask_m,
+        block_mask_n=block_mask_n,
     )[1]
 
 
@@ -732,6 +866,9 @@ def sdnq_triton_atten_bwd(
     do_grad_q: bool = True,
     do_grad_k: bool = True,
     do_grad_v: bool = True,
+    block_mask: torch.Tensor | None = None,
+    block_mask_m: int = 0,
+    block_mask_n: int = 0,
 ) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
     if not do_grad_q and not do_grad_k and not do_grad_v:
         return None, None, None
@@ -740,6 +877,12 @@ def sdnq_triton_atten_bwd(
         sm_scale = QHD ** -0.5
     if out_dtype is None:
         out_dtype = grad_output.dtype
+
+    block_count = block_index = block_count_t = block_index_t = None
+    if block_mask is not None:
+        # dq walks the kept kv blocks of each query block, dkv the query blocks that kept each kv block
+        block_count, block_index = get_block_mask_input(block_mask, query.shape[0], query.shape[1])
+        block_count_t, block_index_t = get_block_mask_input(block_mask.transpose(-1, -2), query.shape[0], query.shape[1])
 
     if use_hadamard:
         hadamard = get_hadamard(hadamard_group_size, dtype=grad_output.dtype, device=grad_output.device)
@@ -760,6 +903,10 @@ def sdnq_triton_atten_bwd(
             is_causal=is_causal,
             use_fp16_accum=use_fp16_accum,
             out_dtype=out_dtype,
+            block_count=block_count,
+            block_index=block_index,
+            block_mask_m=block_mask_m,
+            block_mask_n=block_mask_n,
         )
         if use_hadamard:
             dq = rotate_hadamard_compiled(dq, group_size=hadamard_group_size, hadamard=hadamard)
@@ -780,6 +927,10 @@ def sdnq_triton_atten_bwd(
             is_causal=is_causal,
             use_fp16_accum=use_fp16_accum,
             out_dtype=out_dtype,
+            block_count=block_count_t,
+            block_index=block_index_t,
+            block_mask_m=block_mask_m,
+            block_mask_n=block_mask_n,
         )
     elif do_grad_k:
         dv = None
@@ -795,6 +946,10 @@ def sdnq_triton_atten_bwd(
             is_causal=is_causal,
             use_fp16_accum=use_fp16_accum,
             out_dtype=out_dtype,
+            block_count=block_count_t,
+            block_index=block_index_t,
+            block_mask_m=block_mask_m,
+            block_mask_n=block_mask_n,
         )
     elif do_grad_v:
         dk = None
@@ -810,6 +965,10 @@ def sdnq_triton_atten_bwd(
             is_causal=is_causal,
             use_fp16_accum=use_fp16_accum,
             out_dtype=out_dtype,
+            block_count=block_count_t,
+            block_index=block_index_t,
+            block_mask_m=block_mask_m,
+            block_mask_n=block_mask_n,
         )
     if do_grad_k:
         if use_hadamard:
@@ -841,6 +1000,9 @@ class SDNQAttenBackward(torch.autograd.Function):
         do_quantize: bool,
         use_fp16_accum: bool,
         out_dtype: torch.dtype | None,
+        block_mask: torch.Tensor | None = None,
+        block_mask_m: int = 0,
+        block_mask_n: int = 0,
     ) -> torch.Tensor:
         ctx.QHD = query.shape[-1]
         ctx.KHD = key.shape[-1]
@@ -849,6 +1011,8 @@ class SDNQAttenBackward(torch.autograd.Function):
         ctx.do_quantize = do_quantize
         ctx.use_fp16_accum = use_fp16_accum
         ctx.pv_matmul_dtype = pv_matmul_dtype
+        ctx.block_mask_m = block_mask_m
+        ctx.block_mask_n = block_mask_n
 
         (
             out, lse, query, key, value,
@@ -868,17 +1032,20 @@ class SDNQAttenBackward(torch.autograd.Function):
             use_fp16_accum=use_fp16_accum,
             out_dtype=out_dtype,
             return_backward=True,
+            block_mask=block_mask,
+            block_mask_m=block_mask_m,
+            block_mask_n=block_mask_n,
         )
 
         ctx.sm_scale = sm_scale
         ctx.use_hadamard = use_hadamard
         ctx.hadamard_group_size = hadamard_group_size
-        ctx.save_for_backward(out, lse, query, key, value, query_scale, key_scale, value_scale, attn_mask)
+        ctx.save_for_backward(out, lse, query, key, value, query_scale, key_scale, value_scale, attn_mask, block_mask)
         return out[..., :ctx.VHD]
 
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
-        out, lse, query, key, value, query_scale, key_scale, value_scale, attn_mask = ctx.saved_tensors
+        out, lse, query, key, value, query_scale, key_scale, value_scale, attn_mask, block_mask = ctx.saved_tensors
         dq, dk, dv = sdnq_triton_atten_bwd(
             grad_output, out, lse, query, key, value,
             query_scale, key_scale, value_scale,
@@ -894,8 +1061,11 @@ class SDNQAttenBackward(torch.autograd.Function):
             do_grad_q=ctx.needs_input_grad[0],
             do_grad_k=ctx.needs_input_grad[1],
             do_grad_v=ctx.needs_input_grad[2],
+            block_mask=block_mask,
+            block_mask_m=ctx.block_mask_m,
+            block_mask_n=ctx.block_mask_n,
         )
-        return dq, dk, dv, *(None,)*11
+        return dq, dk, dv, *(None,)*14
 
 
 def sdnq_triton_atten_with_backward(
@@ -915,6 +1085,9 @@ def sdnq_triton_atten_with_backward(
         do_quantize: bool = True,
         use_fp16_accum: bool = False,
         out_dtype: torch.dtype | None = None,
+        block_mask: torch.Tensor | None = None,
+        block_mask_m: int = 0,
+        block_mask_n: int = 0,
     ) -> torch.Tensor:
     return SDNQAttenBackward.apply(
         query, key, value,
@@ -928,7 +1101,10 @@ def sdnq_triton_atten_with_backward(
         pv_matmul_dtype,
         do_quantize,
         use_fp16_accum,
-        out_dtype
+        out_dtype,
+        block_mask,
+        block_mask_m,
+        block_mask_n,
     )
 
 


### PR DESCRIPTION
`sdnq_triton_atten` gains a `block_mask`: a bool or int8 tensor of shape `(batch or 1, heads or 1, ceil(QN / block_mask_m), ceil(KN / block_mask_n))`, where `block_mask_m` and `block_mask_n` give the block size in tokens. A zero drops that whole block of scores. It composes with `attn_mask`, the dense path is untouched, and the second commit puts the same mask through the backward.

The point is long sequences. `attn_mask` cannot serve this: it has to load a tile before it can skip it, and the branch in the loop costs the pipelining, so at 38,222 tokens with a quarter of the keys live it runs 524.8 ms against 440.5 dense. Size rules it out anyway, since a token mask at that length is 1.36 GiB head-shared and 76 GiB per head, against 175 KiB or 9.6 MB for the block mask. A per-head selection is simply not representable as tokens.

If a caller does hold a token mask, the block mask coarsens it rather than replacing it: a block is kept when any of its tokens is, both are passed, and the block list skips the wholly empty blocks without loading their mask tiles. Conversion is a max-pool plus the list build, 1.2 ms at 16k tokens and 13.1 ms at 38k, and the composed output is bitwise the token path's in every case measured. It pays when the mask has block-scale structure, which padding, document and windowed masks do: at a quarter of the keys live, 12.5 ms token-only against 6.0 ms converted and composed at 16k, and 524.8 against 262.8 at 38k. A mask scattered at the same density coarsens to a fully dense block mask, gains nothing and costs 6 to 13 percent.

The entry converts the mask to a count and an ascending index list of kept key blocks per query block, the same form FlexAttention's BlockMask holds, and the kernel walks only that list: a runtime trip count, one chunk load per tile, no branch in the body and no stride argument. The backward runs the same walk from both sides, dkv reading the lists built on the transposed mask. Every autotune tile has to nest inside a mask block, so `prune_configs` keeps only tiles that divide it and raises, naming the env lists, when none do. The default lists nest a 128x64 block.

RTX 3090, bf16, 38,222 tokens, 56 heads, head_dim 128, int8 qk: dense 405.2 ms, every block kept 416.6 ms (2.8 percent, the list conversion), 30 percent kept 132.2 ms (x3.07), 15 percent kept 71.2 ms (x5.69). Forward plus backward at 16,384 tokens and 8 heads: dense 59.4 ms, 31 percent kept 20.2 ms (x2.94).

Tested by an offline suite of 22 forward rows and 5 backward rows, pinned to one autotune config per run and swept over every tile pair in {32, 64, 128} x {16, 32, 64}: bitwise equal to the dense kernel with every block kept on six tiles and one ulp on three, within one ulp of the token-expanded mask on the same selection, plus ragged tails, GQA, broadcasts, empty blocks, composition with a padding mask, and fp32 autograd as the gradient reference. A 124-frame MiniMax H3 video through the dense path is bit-identical before and after.